### PR TITLE
fix bug when encounting non-whitelisted token

### DIFF
--- a/src/shortcode-tokenizer.js
+++ b/src/shortcode-tokenizer.js
@@ -430,15 +430,6 @@ export default class ShortcodeTokenizer {
 
     let match = this.buf.match(rxEnclosure)
 
-    // Whitelist - Treat as text if not whitelisted
-    if (match && this.options.whitelist) {
-      let name = match[1].match(rxName)[1]
-
-      if (this.options.whitelist.indexOf(name) === -1) {
-        match = null
-      }
-    }
-
     // all text
     if (match === null) {
       let token = new Token(TEXT, this.buf, this.pos, this.options.strict)
@@ -460,8 +451,19 @@ export default class ShortcodeTokenizer {
     }
 
     // matching token
+
+    // set TokenType, non-whitelisted = TEXT
+    const name = match[1].match(rxName)[1];
+    let tokenType = null;
+    if (this.options.whitelist && this.options.whitelist.indexOf(name) === -1) {
+      tokenType = TEXT;
+    } else {
+      tokenType = getTokenType(match[0]);
+    }
+
+    // Regular TOKEN
     tokens.push(new Token(
-      getTokenType(match[0]),
+      tokenType,
       match[0],
       this.pos + match.index,
       this.options.strict

--- a/src/shortcode-tokenizer.js
+++ b/src/shortcode-tokenizer.js
@@ -450,9 +450,8 @@ export default class ShortcodeTokenizer {
       ))
     }
 
-    // matching token
-
-    // set TokenType, non-whitelisted = TEXT
+    // set TokenType,
+    // non-whitelisted = TEXT
     const name = match[1].match(rxName)[1];
     let tokenType = null;
     if (this.options.whitelist && this.options.whitelist.indexOf(name) === -1) {

--- a/test/unit/shortcode-tokenizer.test.js
+++ b/test/unit/shortcode-tokenizer.test.js
@@ -176,13 +176,16 @@ describe('ShortcodeTokenizer', () => {
     })
 
     it('should treat non-whitelisted tokens as TEXT', () => {
-      let input = '[thisone] [notthisone]'
+      let input = '[notthisone] [thisone]'
       tokenizer.options.whitelist = ['thisone'];
       const result = tokenizer.tokens(input);
-      expect(result[0].name).to.equal('thisone');
-      expect(result[0].type).to.equal('OPEN');
+      console.log(result)
+      expect(result[0].name).to.equal(null);
+      expect(result[0].type).to.equal("TEXT");
       expect(result[1].name).to.equal(null);
-      expect(result[1].type).to.equal('TEXT');
+      expect(result[1].type).to.equal("TEXT");
+      expect(result[2].name).to.equal("thisone");
+      expect(result[2].type).to.equal("OPEN");
     })
   })
 

--- a/test/unit/shortcode-tokenizer.test.js
+++ b/test/unit/shortcode-tokenizer.test.js
@@ -179,7 +179,6 @@ describe('ShortcodeTokenizer', () => {
       let input = '[notthisone] [thisone]'
       tokenizer.options.whitelist = ['thisone'];
       const result = tokenizer.tokens(input);
-      console.log(result)
       expect(result[0].name).to.equal(null);
       expect(result[0].type).to.equal("TEXT");
       expect(result[1].name).to.equal(null);


### PR DESCRIPTION
the bug was returning the remainder of the buffer as text. Fixed it to return the non-whitelisted token as TEXT, and continue parsing the remainder of the buffer.